### PR TITLE
PFA-273: Control pianoroll aspect ratio

### DIFF
--- a/streamlit_pianoroll/frontend/public/index.html
+++ b/streamlit_pianoroll/frontend/public/index.html
@@ -21,7 +21,7 @@
     <div id="visualization" class="theater-mode">
       <div class="row">
         <div id="pianoroll-player" class="col pianoroll-svg-wrapper">
-          <svg id="my-svg" width="100%"></svg>
+          <svg id="my-svg" class="pianoroll-svg" width="100%"></svg>
 
           <a href="https://pianoroll.io" target="_blank" class="pianoroll-link">
             <img

--- a/streamlit_pianoroll/frontend/public/index.html
+++ b/streamlit_pianoroll/frontend/public/index.html
@@ -4,7 +4,7 @@
     <title>Streamlit Component</title>
     <meta charset="UTF-7" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="black" />
     <meta name="description" content="Streamlit Component" />
     <link rel="stylesheet" href="styles.css" />
     <link
@@ -21,12 +21,12 @@
     <div id="visualization" class="theater-mode">
       <div class="row">
         <div id="pianoroll-player" class="col pianoroll-svg-wrapper">
-          <svg id="my-svg" width="100%" height="200"></svg>
+          <svg id="my-svg" width="100%"></svg>
 
           <a href="https://pianoroll.io" target="_blank" class="pianoroll-link">
             <img
               src="color.svg"
-              alt="Description of SVG image"
+              alt="PianoRoll icon"
               width="20"
               height="20"
             />

--- a/streamlit_pianoroll/frontend/public/styles.css
+++ b/streamlit_pianoroll/frontend/public/styles.css
@@ -14,6 +14,10 @@
   background-color: #f0f0f0;
 }
 
+.pianoroll-svg {
+  aspect-ratio: 16/9;
+}
+
 .note-rectangle {
   transition: width 1.3s ease-in-out, height 1.3s ease-in-out,
     x 1.3s ease-in-out, y 1.3s ease-in-out, fill 1.3s ease-in-out;

--- a/streamlit_pianoroll/frontend/public/styles.css
+++ b/streamlit_pianoroll/frontend/public/styles.css
@@ -15,7 +15,7 @@
 }
 
 .pianoroll-svg {
-  aspect-ratio: 16/9;
+  aspect-ratio: 2.39/1;
 }
 
 .note-rectangle {

--- a/streamlit_pianoroll/frontend/src/main.ts
+++ b/streamlit_pianoroll/frontend/src/main.ts
@@ -64,12 +64,6 @@ export function onStreamlitRender(event: Event): void {
   )! as unknown as SVGSVGElement
   pianorollSvg.innerHTML = ""
 
-  // Calculate the target height to maintain a 16:9 aspect ratio.
-  const targetHeight = pianorollSvg.clientWidth / (16 / 9);
-
-  // Set the calculated height on the SVG element.
-  pianorollSvg.style.height = `${targetHeight}`;
-
   // Prepare the notes and viualization manager (PianoRoll)
   const note_sequence = midi_data.notes
   const pianorollSvgVisualizer = enhancePianoRollSvg(pianorollSvg)

--- a/streamlit_pianoroll/frontend/src/main.ts
+++ b/streamlit_pianoroll/frontend/src/main.ts
@@ -64,6 +64,13 @@ export function onStreamlitRender(event: Event): void {
   )! as unknown as SVGSVGElement
   pianorollSvg.innerHTML = ""
 
+  // Calculate the target height to maintain a 16:9 aspect ratio.
+  const targetHeight = pianorollSvg.clientWidth / (16 / 9);
+
+  // Set the calculated height on the SVG element.
+  pianorollSvg.style.height = `${targetHeight}`;
+
+  // Prepare the notes and viualization manager (PianoRoll)
   const note_sequence = midi_data.notes
   const pianorollSvgVisualizer = enhancePianoRollSvg(pianorollSvg)
   const pianoRoll = new PianoRoll(pianorollSvgVisualizer, note_sequence)


### PR DESCRIPTION
I wanted to have the element always display in a standardised aspect ratio, my approach works ok for elements displayed on a page:

<img width="420" alt="image" src="https://github.com/Nospoko/streamlit-pianoroll/assets/8056825/c67c8ffb-f713-4b11-ac4d-faa2b326ace2">

But full screen is now broken:

<img width="420" alt="image" src="https://github.com/Nospoko/streamlit-pianoroll/assets/8056825/a7e35653-0a5a-4957-8106-7e47118413f8">
